### PR TITLE
check acceptable media types

### DIFF
--- a/src/main/java/io/katharsis/rs/KatharsisFilter.java
+++ b/src/main/java/io/katharsis/rs/KatharsisFilter.java
@@ -18,6 +18,7 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
@@ -75,6 +76,19 @@ public class KatharsisFilter implements ContainerRequestFilter {
         if (requestContext.hasEntity() && !requestContext.getMediaType().isCompatible(JsonApiMediaType.APPLICATION_JSON_API_TYPE)) {
             return;
         }
+
+        boolean acceptable = false;
+        for (MediaType acceptableMediaType : requestContext.getAcceptableMediaTypes()) {
+            if (acceptableMediaType.isCompatible(JsonApiMediaType.APPLICATION_JSON_API_TYPE)) {
+                acceptable = true;
+                break;
+            }
+        }
+
+        if (!acceptable) {
+            return;
+        }
+
         try {
             dispatchRequest(requestContext);
         } catch (Exception e) {

--- a/src/test/java/io/katharsis/rs/controller/KatharsisControllerWithoutPrefixTest.java
+++ b/src/test/java/io/katharsis/rs/controller/KatharsisControllerWithoutPrefixTest.java
@@ -46,14 +46,26 @@ public class KatharsisControllerWithoutPrefixTest extends KatharsisControllerTes
     }
 
     @Test
-    public void onNonJsonApiCallShouldBeIgnored() {
+    public void onNonJsonApiPostCallShouldBeIgnored() {
         // WHEN
         Response response = target("tasks/1")
                 .request(MediaType.MEDIA_TYPE_WILDCARD)
                 .post(Entity.entity("binary", MediaType.APPLICATION_OCTET_STREAM_TYPE));
 
+        // THEN
         assertThat(response.getStatusInfo().getFamily()).isEqualTo(Response.Status.Family.SUCCESSFUL);
         String responseString = response.readEntity(String.class);
         assertThat(responseString).isEqualTo(SampleOverlayingController.NON_KATHARSIS_RESOURCE_OVERLAY_RESPONSE);
+    }
+
+    @Test
+    public void onNonJsonApiGetCallShouldBeIgnored() {
+        // WHEN
+        String response = target("tasks/1")
+                .request(MediaType.TEXT_PLAIN_TYPE)
+                .get(String.class);
+
+        // THEN
+        assertThat(response).isEqualTo(SampleOverlayingController.NON_KATHARSIS_RESOURCE_OVERLAY_RESPONSE);
     }
 }

--- a/src/test/java/io/katharsis/rs/controller/SampleOverlayingController.java
+++ b/src/test/java/io/katharsis/rs/controller/SampleOverlayingController.java
@@ -1,6 +1,7 @@
 package io.katharsis.rs.controller;
 
 import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -15,9 +16,15 @@ public class SampleOverlayingController {
 
     public static final String NON_KATHARSIS_RESOURCE_OVERLAY_RESPONSE = "NON_KATHARSIS_RESOURCE_OVERLAY_RESPONSE";
 
-    @POST
+    @GET
     @Path("{id}")
     public Response getRequest(@PathParam("id") final int taskId) {
+        return Response.ok(NON_KATHARSIS_RESOURCE_OVERLAY_RESPONSE).build();
+    }
+
+    @POST
+    @Path("{id}")
+    public Response postRequest(@PathParam("id") final int taskId) {
         return Response.ok(NON_KATHARSIS_RESOURCE_OVERLAY_RESPONSE).build();
     }
 


### PR DESCRIPTION
extends #18 to also check the accept header of the client request. If jsonapi is not within the acceptable media types, then the request is ignored too