### PR TITLE
JaxRsParameterProvider uses a registry of parameter providers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,7 @@
-# katharsis-rs v2.1.2 git changelog
+# katharsis-rs v2.1.3-SNAPSHOT git changelog
 
-
-**v2.1.2**  
-2015-12-09    v2.1.2 (Patryk Orwat)  
+2015-12-09    JaxRsParameterProvider uses a registry of parameter providers to provide values from the ContainerRequestContext (Cade Parker)  
+2015-12-08    v2.1.2 (Patryk Orwat)  
 2015-12-08    katharsis-project/katharsis-core[#186](https://github.com/katharsis-project/katharsis-rs/issues/186) made reflections optional (Patryk Orwat)  
 2015-12-06    katharsis-project/katharsis-core[#186](https://github.com/katharsis-project/katharsis-rs/issues/186) added OSGi headers (Patryk Orwat)  
 2015-12-05    versioneye update (Patryk Orwat)  
@@ -56,7 +55,7 @@
 **v0.9.2**  
 2015-06-25    v0.9.2 (Patryk Orwat)  
 2015-06-17    Add integration test, checking exception handling (Grzegorz Poznachowski)  
-2015-06-17    Started integration test to map exception (Grzegorz Poznachowski)  
+2015-06-16    Started integration test to map exception (Grzegorz Poznachowski)  
 2015-06-13    katharsis-core [#11](https://github.com/katharsis-project/katharsis-rs/issues/11) - included implementation (Patryk Orwat)  
 
 **v0.9.1**  
@@ -69,12 +68,12 @@
 **v0.9.0**  
 2015-06-01    v0.9.0 (Patryk Orwat)  
 2015-06-01    added repositories (Patryk Orwat)  
-2015-05-20    Added support of ExceptionMapping while request processing (Grzegorz Poznachowski)  
+2015-05-19    Added support of ExceptionMapping while request processing (Grzegorz Poznachowski)  
 2015-05-17    changed scope of jersey dependencies to test (Patryk Orwat)  
 2015-05-15    Initial implementation of error handling. (Grzegorz Poznachowski)  
 2015-05-11    Jackson serialization problem fix (Patryk Orwat)  
 2015-05-09    tests fix (Patryk Orwat)  
-2015-05-09    adjustment to core change - type parser (Patryk Orwat)  
+2015-05-08    adjustment to core change - type parser (Patryk Orwat)  
 2015-05-03    adjustment to core change (Patryk Orwat)  
 2015-05-03    added Jackson ObjectMapper configuration (Patryk Orwat)  
 2015-05-03    smallfix - jackson dep problem (Patryk Orwat)  
@@ -82,20 +81,20 @@
 2015-05-01    [#3](https://github.com/katharsis-project/katharsis-rs/issues/3) smallfix (Patryk Orwat)  
 2015-05-01    changed controller to filter, closes [#3](https://github.com/katharsis-project/katharsis-rs/issues/3) (Patryk Orwat)  
 2015-05-01    [#3](https://github.com/katharsis-project/katharsis-rs/issues/3) removed HK2 dependency (Patryk Orwat)  
-2015-04-27    pom refactored (Grzegorz Poznachowski)  
+2015-04-26    pom refactored (Grzegorz Poznachowski)  
 2015-04-20    proper -core version (Grzegorz Poznachowski)  
-2015-04-20    poms using parent (Grzegorz Poznachowski)  
+2015-04-19    poms using parent (Grzegorz Poznachowski)  
 2015-04-15    fixed RequestDispatcherFactory (Patryk Orwat)  
 2015-04-13    fixed RequestDispatcherBuilder usage (Patryk Orwat)  
 2015-04-12    Added support for query params from core (Błażej Krysiak)  
 2015-04-12    decided HK2 to be the main DI provider (Patryk Orwat)  
-2015-04-09    fixed repository (Patryk Orwat)  
-2015-04-04    improved Jackson integration (Patryk Orwat)  
-2015-04-03    improved serialization (Patryk Orwat)  
+2015-04-08    fixed repository (Patryk Orwat)  
+2015-04-03    improved Jackson integration (Patryk Orwat)  
+2015-04-02    improved serialization (Patryk Orwat)  
 2015-03-29    fixes from katharsis-core (Patryk Orwat)  
 2015-03-25    Gitter webhooks integration fix  + test updates. (Błażej Krysiak)  
 2015-03-25    Gitter webhooks integration fix. (Błażej Krysiak)  
-2015-03-25    Gitter webhooks integration (Błażej Krysiak)  
+2015-03-24    Gitter webhooks integration (Błażej Krysiak)  
 2015-03-24    Added bintray deployment. (Błażej Krysiak)  
 2015-03-23    serialization + travis fix (Patryk Orwat)  
 2015-03-19    jersey2 get tests (Patryk Orwat)  

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.katharsis</groupId>
             <artifactId>katharsis-core</artifactId>
             <version>${project.version}</version>

--- a/src/main/java/io/katharsis/rs/KatharsisFeature.java
+++ b/src/main/java/io/katharsis/rs/KatharsisFeature.java
@@ -1,5 +1,6 @@
 package io.katharsis.rs;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.katharsis.dispatcher.RequestDispatcher;
 import io.katharsis.dispatcher.registry.ControllerRegistry;
 import io.katharsis.dispatcher.registry.ControllerRegistryBuilder;
@@ -24,8 +25,6 @@ import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
 import javax.ws.rs.ext.Provider;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 /**
  * Basic Katharsis feature that initializes core classes and provides a starting point to use the framework in
  * another projects.
@@ -43,21 +42,29 @@ public class KatharsisFeature implements Feature {
         this.objectMapper = objectMapper;
         this.jsonServiceLocator = jsonServiceLocator;
     }
-    
+
     public ResourceLookup createResourceLookup(FeatureContext context) {
         String resourceSearchPackage = (String) context
                 .getConfiguration()
                 .getProperty(KatharsisProperties.RESOURCE_SEARCH_PACKAGE);
-    	
+
         return new DefaultResourceLookup(resourceSearchPackage);
     }
-    
+
     public ExceptionMapperLookup createExceptionMapperLookup(FeatureContext context) {
         String resourceSearchPackage = (String) context
                 .getConfiguration()
                 .getProperty(KatharsisProperties.RESOURCE_SEARCH_PACKAGE);
-    	
+
         return new DefaultExceptionMapperLookup(resourceSearchPackage);
+    }
+
+    private RequestContextParameterProviderLookup createRequestContextProviderLookup(FeatureContext context) {
+        String resourceSearchPackage = (String) context
+                .getConfiguration()
+                .getProperty(KatharsisProperties.RESOURCE_SEARCH_PACKAGE);
+
+        return new RequestContextParameterProviderLookup(resourceSearchPackage);
     }
 
     @Override
@@ -80,13 +87,20 @@ public class KatharsisFeature implements Feature {
         try {
         	ExceptionMapperLookup exceptionMapperLookup = createExceptionMapperLookup(context);
             ExceptionMapperRegistry exceptionMapperRegistry = buildExceptionMapperRegistry(exceptionMapperLookup);
-            katharsisFilter = createKatharsisFilter(resourceRegistry, exceptionMapperRegistry, webPathPrefix);
+            RequestContextParameterProviderLookup containerRequestContextProviderLookup = createRequestContextProviderLookup(context);
+            RequestContextParameterProviderRegistry parameterProviderRegistry = buildParameterProviderRegistry(containerRequestContextProviderLookup);
+            katharsisFilter = createKatharsisFilter(resourceRegistry, exceptionMapperRegistry, parameterProviderRegistry, webPathPrefix);
         } catch (Exception e) {
             throw new WebApplicationException(e);
         }
         context.register(katharsisFilter);
 
         return true;
+    }
+
+    private RequestContextParameterProviderRegistry buildParameterProviderRegistry(RequestContextParameterProviderLookup containerRequestContextProviderLookup) {
+        RequestContextParameterProviderRegistryBuilder builder = new RequestContextParameterProviderRegistryBuilder();
+        return builder.build(containerRequestContextProviderLookup);
     }
 
     private String buildServiceUrl(String resourceDefaultDomain, String webPathPrefix) {
@@ -105,10 +119,10 @@ public class KatharsisFeature implements Feature {
     }
 
     private KatharsisFilter createKatharsisFilter(ResourceRegistry resourceRegistry,
-        ExceptionMapperRegistry exceptionMapperRegistry, String webPathPrefix) throws Exception {
+        ExceptionMapperRegistry exceptionMapperRegistry, RequestContextParameterProviderRegistry parameterProviderRegistry, String webPathPrefix) throws Exception {
         RequestDispatcher requestDispatcher = createRequestDispatcher(resourceRegistry, exceptionMapperRegistry);
 
-        return new KatharsisFilter(objectMapper, resourceRegistry, requestDispatcher, webPathPrefix);
+        return new KatharsisFilter(objectMapper, resourceRegistry, requestDispatcher, parameterProviderRegistry, webPathPrefix);
     }
 
     private RequestDispatcher createRequestDispatcher(ResourceRegistry resourceRegistry,

--- a/src/main/java/io/katharsis/rs/KatharsisFilter.java
+++ b/src/main/java/io/katharsis/rs/KatharsisFilter.java
@@ -51,13 +51,15 @@ public class KatharsisFilter implements ContainerRequestFilter {
     private ObjectMapper objectMapper;
     private ResourceRegistry resourceRegistry;
     private RequestDispatcher requestDispatcher;
+    private RequestContextParameterProviderRegistry parameterProviderRegistry;
     private String webPathPrefix;
 
     public KatharsisFilter(ObjectMapper objectMapper, ResourceRegistry resourceRegistry, RequestDispatcher
-        requestDispatcher, String webPathPrefix) {
+            requestDispatcher, RequestContextParameterProviderRegistry parameterProviderRegistry, String webPathPrefix) {
         this.objectMapper = objectMapper;
         this.resourceRegistry = resourceRegistry;
         this.requestDispatcher = requestDispatcher;
+        this.parameterProviderRegistry = parameterProviderRegistry;
         this.webPathPrefix = parsePrefix(webPathPrefix);
     }
 
@@ -112,7 +114,7 @@ public class KatharsisFilter implements ContainerRequestFilter {
             String method = requestContext.getMethod();
             RequestBody requestBody = inputStreamToBody(requestContext.getEntityStream());
 
-            JaxRsParameterProvider parameterProvider = new JaxRsParameterProvider(objectMapper, requestContext);
+            JaxRsParameterProvider parameterProvider = new JaxRsParameterProvider(objectMapper, requestContext, parameterProviderRegistry);
             katharsisResponse = requestDispatcher
                 .dispatchRequest(jsonPath, method, requestParams, parameterProvider, requestBody);
         } catch (KatharsisMappableException e) {

--- a/src/main/java/io/katharsis/rs/RequestContextParameterProviderLookup.java
+++ b/src/main/java/io/katharsis/rs/RequestContextParameterProviderLookup.java
@@ -1,0 +1,38 @@
+package io.katharsis.rs;
+
+import io.katharsis.resource.exception.init.InvalidResourceException;
+import io.katharsis.rs.provider.RequestContextParameterProvider;
+import org.reflections.Reflections;
+
+import java.util.Scanner;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class RequestContextParameterProviderLookup {
+
+    private String resourceSearchPackage;
+
+    public RequestContextParameterProviderLookup(String resourceSearchPackage) {
+        this.resourceSearchPackage = resourceSearchPackage;
+    }
+
+    public Set<RequestContextParameterProvider> getRequestContextProviders() {
+        Reflections reflections;
+        if(this.resourceSearchPackage != null) {
+            String[] exceptionMapperClasses = this.resourceSearchPackage.split(",");
+            reflections = new Reflections(exceptionMapperClasses);
+        } else {
+            reflections = new Reflections(this.resourceSearchPackage, new Scanner[0]);
+        }
+
+        Set<Class<? extends RequestContextParameterProvider>> parameterProviderClasses = reflections.getSubTypesOf(RequestContextParameterProvider.class);
+
+        return parameterProviderClasses.stream().map((parameterProviderClazz) -> {
+            try {
+                return parameterProviderClazz.newInstance();
+            } catch (Exception e) {
+                throw new InvalidResourceException(parameterProviderClazz.getCanonicalName() + " can not be initialized", e);
+            }
+        }).collect(Collectors.<RequestContextParameterProvider>toSet());
+    }
+}

--- a/src/main/java/io/katharsis/rs/RequestContextParameterProviderRegistry.java
+++ b/src/main/java/io/katharsis/rs/RequestContextParameterProviderRegistry.java
@@ -1,0 +1,34 @@
+package io.katharsis.rs;
+
+import io.katharsis.rs.provider.RequestContextParameterProvider;
+
+import java.lang.reflect.Parameter;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
+
+public class RequestContextParameterProviderRegistry {
+
+    private Set<RequestContextParameterProvider> parameterProviders;
+
+    public RequestContextParameterProviderRegistry(Set<RequestContextParameterProvider> parameterProviders) {
+        this.parameterProviders = parameterProviders;
+    }
+
+    public Optional<RequestContextParameterProvider> findProviderFor(Parameter parameter) {
+        for (RequestContextParameterProvider parameterProvider : parameterProviders) {
+            if (parameterProvider.provides(parameter)) {
+                return Optional.of(parameterProvider);
+            }
+        }
+        return Optional.empty();
+    }
+
+    public Collection<RequestContextParameterProvider> getParameterProviders() {
+        return parameterProviders;
+    }
+
+    public void setParameterProviders(Set<RequestContextParameterProvider> parameterProviders) {
+        this.parameterProviders = parameterProviders;
+    }
+}

--- a/src/main/java/io/katharsis/rs/RequestContextParameterProviderRegistryBuilder.java
+++ b/src/main/java/io/katharsis/rs/RequestContextParameterProviderRegistryBuilder.java
@@ -1,0 +1,32 @@
+package io.katharsis.rs;
+
+import io.katharsis.rs.provider.ContainerRequestContextProvider;
+import io.katharsis.rs.provider.CookieParamProvider;
+import io.katharsis.rs.provider.HeaderParamProvider;
+import io.katharsis.rs.provider.RequestContextParameterProvider;
+import io.katharsis.rs.provider.SecurityContextProvider;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class RequestContextParameterProviderRegistryBuilder {
+
+    private Set<RequestContextParameterProvider> providers = new HashSet<>();
+
+    public RequestContextParameterProviderRegistry build(RequestContextParameterProviderLookup containerRequestContextProviderLookup) {
+        addKatharsisDefaultProviders();
+        containerRequestContextProviderLookup.getRequestContextProviders().stream().forEach(this::registerRequestContextProvider);
+        return new RequestContextParameterProviderRegistry(providers);
+    }
+
+    private void addKatharsisDefaultProviders() {
+        registerRequestContextProvider(new ContainerRequestContextProvider());
+        registerRequestContextProvider(new SecurityContextProvider());
+        registerRequestContextProvider(new CookieParamProvider());
+        registerRequestContextProvider(new HeaderParamProvider());
+    }
+
+    private void registerRequestContextProvider(RequestContextParameterProvider requestContextParameterProvider) {
+        providers.add(requestContextParameterProvider);
+    }
+}

--- a/src/main/java/io/katharsis/rs/provider/ContainerRequestContextProvider.java
+++ b/src/main/java/io/katharsis/rs/provider/ContainerRequestContextProvider.java
@@ -1,0 +1,19 @@
+package io.katharsis.rs.provider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import java.lang.reflect.Parameter;
+
+public class ContainerRequestContextProvider implements RequestContextParameterProvider<ContainerRequestContext> {
+
+    @Override
+    public ContainerRequestContext provideValue(Parameter parameter, ContainerRequestContext requestContext, ObjectMapper objectMapper) {
+        return requestContext;
+    }
+
+    @Override
+    public boolean provides(Parameter parameter) {
+        return ContainerRequestContext.class.isAssignableFrom(parameter.getType());
+    }
+}

--- a/src/main/java/io/katharsis/rs/provider/CookieParamProvider.java
+++ b/src/main/java/io/katharsis/rs/provider/CookieParamProvider.java
@@ -1,0 +1,41 @@
+package io.katharsis.rs.provider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.ws.rs.CookieParam;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.Cookie;
+import java.io.IOException;
+import java.lang.reflect.Parameter;
+
+public class CookieParamProvider implements RequestContextParameterProvider<Object> {
+
+    @Override
+    public Object provideValue(Parameter parameter, ContainerRequestContext requestContext, ObjectMapper objectMapper) {
+        Object returnValue;
+        String cookieName = parameter.getAnnotation(CookieParam.class).value();
+        Cookie cookie = requestContext.getCookies().get(cookieName);
+        if (cookie == null) {
+            return null;
+        } else {
+            if (Cookie.class.isAssignableFrom(parameter.getType())) {
+                returnValue = cookie;
+            } else if (String.class.isAssignableFrom(parameter.getType())) {
+                returnValue = cookie.getValue();
+            } else {
+                try {
+                    returnValue = objectMapper.readValue(cookie.getValue(), parameter.getType());
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+
+        return returnValue;
+    }
+
+    @Override
+    public boolean provides(Parameter parameter) {
+        return parameter.isAnnotationPresent(CookieParam.class);
+    }
+}

--- a/src/main/java/io/katharsis/rs/provider/HeaderParamProvider.java
+++ b/src/main/java/io/katharsis/rs/provider/HeaderParamProvider.java
@@ -1,0 +1,37 @@
+package io.katharsis.rs.provider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.container.ContainerRequestContext;
+import java.io.IOException;
+import java.lang.reflect.Parameter;
+
+public class HeaderParamProvider implements RequestContextParameterProvider<Object> {
+
+    @Override
+    public Object provideValue(Parameter parameter, ContainerRequestContext requestContext, ObjectMapper objectMapper) {
+        Object returnValue;
+        String value = requestContext.getHeaderString(parameter.getAnnotation(HeaderParam.class).value());
+        if (value == null) {
+            return null;
+        } else {
+            if (String.class.isAssignableFrom(parameter.getType())) {
+                returnValue = value;
+            } else {
+                try {
+                    returnValue = objectMapper.readValue(value, parameter.getType());
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+
+        return returnValue;
+    }
+
+    @Override
+    public boolean provides(Parameter parameter) {
+        return parameter.isAnnotationPresent(HeaderParam.class);
+    }
+}

--- a/src/main/java/io/katharsis/rs/provider/RequestContextParameterProvider.java
+++ b/src/main/java/io/katharsis/rs/provider/RequestContextParameterProvider.java
@@ -1,0 +1,13 @@
+package io.katharsis.rs.provider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import java.lang.reflect.Parameter;
+
+public interface RequestContextParameterProvider<T>  {
+
+    public <T> T provideValue(Parameter parameter, ContainerRequestContext requestContext, ObjectMapper objectMapper);
+
+    public boolean provides(Parameter parameter);
+}

--- a/src/main/java/io/katharsis/rs/provider/SecurityContextProvider.java
+++ b/src/main/java/io/katharsis/rs/provider/SecurityContextProvider.java
@@ -1,0 +1,21 @@
+package io.katharsis.rs.provider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.SecurityContext;
+import java.lang.reflect.Parameter;
+
+public class SecurityContextProvider implements RequestContextParameterProvider<SecurityContext> {
+
+    @Override
+    public SecurityContext provideValue(Parameter parameter, ContainerRequestContext requestContext, ObjectMapper objectMapper) {
+        return requestContext.getSecurityContext();
+    }
+
+    @Override
+    public boolean provides(Parameter parameter) {
+        return SecurityContext.class.isAssignableFrom(parameter.getType());
+    }
+
+}

--- a/src/test/java/io/katharsis/rs/resource/provider/AuthRequest.java
+++ b/src/test/java/io/katharsis/rs/resource/provider/AuthRequest.java
@@ -1,0 +1,29 @@
+package io.katharsis.rs.resource.provider;
+
+public class AuthRequest {
+
+    private String authType;
+    private String value;
+
+    public AuthRequest(String authType, String value) {
+        this.authType = authType;
+        this.value = value;
+    }
+
+    public static AuthRequest fromAuthorizationHeader(String authorizationHeaderValue) {
+        String[] authComponents = authorizationHeaderValue.trim().split(" ");
+
+        return new AuthRequest(authComponents[0], authComponents[1]);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        AuthRequest that = (AuthRequest) o;
+
+        return this.authType.equals(that.authType)
+                && this.value.equals(that.value);
+    }
+}

--- a/src/test/java/io/katharsis/rs/resource/provider/AuthRequestProvider.java
+++ b/src/test/java/io/katharsis/rs/resource/provider/AuthRequestProvider.java
@@ -1,0 +1,19 @@
+package io.katharsis.rs.resource.provider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.katharsis.rs.provider.RequestContextParameterProvider;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import java.lang.reflect.Parameter;
+
+public class AuthRequestProvider implements RequestContextParameterProvider<AuthRequest> {
+    @Override
+    public AuthRequest provideValue(Parameter parameter, ContainerRequestContext requestContext, ObjectMapper objectMapper) {
+        return AuthRequest.fromAuthorizationHeader(requestContext.getHeaderString("Authorization"));
+    }
+
+    @Override
+    public boolean provides(Parameter parameter) {
+        return AuthRequest.class.isAssignableFrom(parameter.getType());
+    }
+}

--- a/src/test/java/io/katharsis/rs/resource/provider/Foo.java
+++ b/src/test/java/io/katharsis/rs/resource/provider/Foo.java
@@ -1,0 +1,11 @@
+package io.katharsis.rs.resource.provider;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Foo {
+}

--- a/src/test/java/io/katharsis/rs/resource/provider/FooProvider.java
+++ b/src/test/java/io/katharsis/rs/resource/provider/FooProvider.java
@@ -1,0 +1,20 @@
+package io.katharsis.rs.resource.provider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.katharsis.rs.provider.RequestContextParameterProvider;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import java.lang.reflect.Parameter;
+
+public class FooProvider implements RequestContextParameterProvider<String> {
+
+    @Override
+    public String provideValue(Parameter parameter, ContainerRequestContext requestContext, ObjectMapper objectMapper) {
+        return "foo";
+    }
+
+    @Override
+    public boolean provides(Parameter parameter) {
+        return parameter.isAnnotationPresent(Foo.class);
+    }
+}


### PR DESCRIPTION
JaxRsParameterProvider uses a registry of parameter providers to provide values from the ContainerRequestContext

Parameter providers can be added to a katharsis-rs project by implementing RequestContextParameterProvider and placing them in the KatharsisProperties.RESOURCE_SEARCH_PACKAGE of the application.