### PR TITLE
use the jsonServiceLocator to instantiate the parameter providers

### DIFF
--- a/src/main/java/io/katharsis/rs/KatharsisFeature.java
+++ b/src/main/java/io/katharsis/rs/KatharsisFeature.java
@@ -67,7 +67,7 @@ public class KatharsisFeature implements Feature {
                 .getConfiguration()
                 .getProperty(KatharsisProperties.RESOURCE_SEARCH_PACKAGE);
 
-        return new RequestContextParameterProviderLookup(resourceSearchPackage);
+        return new RequestContextParameterProviderLookup(resourceSearchPackage, jsonServiceLocator);
     }
 
     @Override

--- a/src/main/java/io/katharsis/rs/parameterProvider/RequestContextParameterProviderLookup.java
+++ b/src/main/java/io/katharsis/rs/parameterProvider/RequestContextParameterProviderLookup.java
@@ -1,5 +1,6 @@
 package io.katharsis.rs.parameterProvider;
 
+import io.katharsis.locator.JsonServiceLocator;
 import io.katharsis.resource.exception.init.InvalidResourceException;
 import io.katharsis.rs.parameterProvider.provider.RequestContextParameterProvider;
 import org.reflections.Reflections;
@@ -11,9 +12,11 @@ import java.util.stream.Collectors;
 public class RequestContextParameterProviderLookup {
 
     private String resourceSearchPackage;
+    private JsonServiceLocator jsonServiceLocator;
 
-    public RequestContextParameterProviderLookup(String resourceSearchPackage) {
+    public RequestContextParameterProviderLookup(String resourceSearchPackage, JsonServiceLocator jsonServiceLocator) {
         this.resourceSearchPackage = resourceSearchPackage;
+        this.jsonServiceLocator = jsonServiceLocator;
     }
 
     public Set<RequestContextParameterProvider> getRequestContextProviders() {
@@ -29,7 +32,7 @@ public class RequestContextParameterProviderLookup {
 
         return parameterProviderClasses.stream().map((parameterProviderClazz) -> {
             try {
-                return parameterProviderClazz.newInstance();
+                return jsonServiceLocator.getInstance(parameterProviderClazz);
             } catch (Exception e) {
                 throw new InvalidResourceException(parameterProviderClazz.getCanonicalName() + " can not be initialized", e);
             }

--- a/src/test/java/io/katharsis/rs/JaxRsParameterProviderTest.java
+++ b/src/test/java/io/katharsis/rs/JaxRsParameterProviderTest.java
@@ -1,6 +1,7 @@
 package io.katharsis.rs;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.katharsis.locator.SampleJsonServiceLocator;
 import io.katharsis.rs.parameterProvider.JaxRsParameterProvider;
 import io.katharsis.rs.parameterProvider.RequestContextParameterProviderLookup;
 import io.katharsis.rs.parameterProvider.RequestContextParameterProviderRegistry;
@@ -25,7 +26,9 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class JaxRsParameterProviderTest {
@@ -53,7 +56,7 @@ public class JaxRsParameterProviderTest {
     }
 
     private RequestContextParameterProviderLookup createRequestContextProviderLookup() {
-        return new RequestContextParameterProviderLookup("io.katharsis.rs.resource");
+        return new RequestContextParameterProviderLookup("io.katharsis.rs.resource", new SampleJsonServiceLocator());
     }
 
     private RequestContextParameterProviderRegistry buildParameterProviderRegistry(RequestContextParameterProviderLookup containerRequestContextProviderLookup) {


### PR DESCRIPTION
Instead of just using clazz.newInstance, it would be better if the RequestContextParameterProviderLookup could take advantage of the JsonServiceLocator of the KatharsisFeature so I can inject dependencies into the providers when they are created.