### PR TITLE
Multiple code improvements - squid:S2864, squid:S1193, squid:S1118, squid:S2326

### DIFF
--- a/src/main/java/io/katharsis/rs/KatharsisFilter.java
+++ b/src/main/java/io/katharsis/rs/KatharsisFilter.java
@@ -97,12 +97,10 @@ public class KatharsisFilter implements ContainerRequestFilter {
 
         try {
             dispatchRequest(requestContext);
+        } catch (WebApplicationException e) {
+            throw e;
         } catch (Exception e) {
-            if (e instanceof WebApplicationException) {
-                throw (WebApplicationException) e;
-            } else {
-                throw new WebApplicationException(e);
-            }
+            throw new WebApplicationException(e);
         }
     }
 
@@ -164,8 +162,8 @@ public class KatharsisFilter implements ContainerRequestFilter {
         MultivaluedMap<String, String> queryParametersMultiMap = uriInfo.getQueryParameters();
         Map<String, Set<String>> queryParameters = new HashMap<>();
 
-        for (String queryName : queryParametersMultiMap.keySet()) {
-            queryParameters.put(queryName, new LinkedHashSet<>(queryParametersMultiMap.get(queryName)));
+        for (Map.Entry<String, List<String>> queryEntry : queryParametersMultiMap.entrySet()) {
+            queryParameters.put(queryEntry.getKey(), new LinkedHashSet<>(queryEntry.getValue()));
         }
 
         return queryParamsBuilder.buildQueryParams(queryParameters);

--- a/src/main/java/io/katharsis/rs/KatharsisProperties.java
+++ b/src/main/java/io/katharsis/rs/KatharsisProperties.java
@@ -47,4 +47,8 @@ public final class KatharsisProperties {
      * @since 0.9.4
      */
     public static final String WEB_PATH_PREFIX = "katharsis.config.web.path.prefix";
+
+    private KatharsisProperties() {
+        throw new InstantiationError("This class should not be instantiated");
+    }
 }

--- a/src/main/java/io/katharsis/rs/parameterProvider/provider/ContainerRequestContextProvider.java
+++ b/src/main/java/io/katharsis/rs/parameterProvider/provider/ContainerRequestContextProvider.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import javax.ws.rs.container.ContainerRequestContext;
 
-public class ContainerRequestContextProvider implements RequestContextParameterProvider<ContainerRequestContext> {
+public class ContainerRequestContextProvider implements RequestContextParameterProvider {
 
     @Override
     public ContainerRequestContext provideValue(Parameter parameter, ContainerRequestContext requestContext, ObjectMapper objectMapper) {

--- a/src/main/java/io/katharsis/rs/parameterProvider/provider/CookieParamProvider.java
+++ b/src/main/java/io/katharsis/rs/parameterProvider/provider/CookieParamProvider.java
@@ -7,7 +7,7 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Cookie;
 import java.io.IOException;
 
-public class CookieParamProvider implements RequestContextParameterProvider<Object> {
+public class CookieParamProvider implements RequestContextParameterProvider {
 
     @Override
     public Object provideValue(Parameter parameter, ContainerRequestContext requestContext, ObjectMapper objectMapper) {

--- a/src/main/java/io/katharsis/rs/parameterProvider/provider/HeaderParamProvider.java
+++ b/src/main/java/io/katharsis/rs/parameterProvider/provider/HeaderParamProvider.java
@@ -6,7 +6,7 @@ import javax.ws.rs.HeaderParam;
 import javax.ws.rs.container.ContainerRequestContext;
 import java.io.IOException;
 
-public class HeaderParamProvider implements RequestContextParameterProvider<Object> {
+public class HeaderParamProvider implements RequestContextParameterProvider {
 
     @Override
     public Object provideValue(Parameter parameter, ContainerRequestContext requestContext, ObjectMapper objectMapper) {

--- a/src/main/java/io/katharsis/rs/parameterProvider/provider/RequestContextParameterProvider.java
+++ b/src/main/java/io/katharsis/rs/parameterProvider/provider/RequestContextParameterProvider.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import javax.ws.rs.container.ContainerRequestContext;
 
-public interface RequestContextParameterProvider<T>  {
+public interface RequestContextParameterProvider {
 
     <T> T provideValue(Parameter parameter, ContainerRequestContext requestContext, ObjectMapper objectMapper);
 

--- a/src/main/java/io/katharsis/rs/parameterProvider/provider/SecurityContextProvider.java
+++ b/src/main/java/io/katharsis/rs/parameterProvider/provider/SecurityContextProvider.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.SecurityContext;
 
-public class SecurityContextProvider implements RequestContextParameterProvider<SecurityContext> {
+public class SecurityContextProvider implements RequestContextParameterProvider {
 
     @Override
     public SecurityContext provideValue(Parameter parameter, ContainerRequestContext requestContext, ObjectMapper objectMapper) {

--- a/src/main/java/io/katharsis/rs/type/JsonApiMediaType.java
+++ b/src/main/java/io/katharsis/rs/type/JsonApiMediaType.java
@@ -2,7 +2,7 @@ package io.katharsis.rs.type;
 
 import javax.ws.rs.core.MediaType;
 
-public class JsonApiMediaType {
+public final class JsonApiMediaType {
     /**
      * A {@code String} constant representing {@value #APPLICATION_JSON_API} media type.
      */
@@ -11,4 +11,8 @@ public class JsonApiMediaType {
      * A {@link MediaType} constant representing {@value #APPLICATION_JSON_API} media type.
      */
     public final static MediaType APPLICATION_JSON_API_TYPE = new MediaType("application", "vnd.api+json");
+
+    private JsonApiMediaType() {
+        throw new InstantiationError("This class should not be instantiated");
+    }
 }

--- a/src/test/java/io/katharsis/rs/resource/provider/AuthRequestProvider.java
+++ b/src/test/java/io/katharsis/rs/resource/provider/AuthRequestProvider.java
@@ -6,7 +6,7 @@ import io.katharsis.rs.parameterProvider.provider.RequestContextParameterProvide
 
 import javax.ws.rs.container.ContainerRequestContext;
 
-public class AuthRequestProvider implements RequestContextParameterProvider<AuthRequest> {
+public class AuthRequestProvider implements RequestContextParameterProvider {
     @Override
     public AuthRequest provideValue(Parameter parameter, ContainerRequestContext requestContext, ObjectMapper objectMapper) {
         return AuthRequest.fromAuthorizationHeader(requestContext.getHeaderString("Authorization"));

--- a/src/test/java/io/katharsis/rs/resource/provider/FooProvider.java
+++ b/src/test/java/io/katharsis/rs/resource/provider/FooProvider.java
@@ -6,7 +6,7 @@ import io.katharsis.rs.parameterProvider.provider.RequestContextParameterProvide
 
 import javax.ws.rs.container.ContainerRequestContext;
 
-public class FooProvider implements RequestContextParameterProvider<String> {
+public class FooProvider implements RequestContextParameterProvider {
 
     @Override
     public String provideValue(Parameter parameter, ContainerRequestContext requestContext, ObjectMapper objectMapper) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S2864 - "entrySet()" should be iterated when both the key and value are needed.
squid:S1193 - Exception types should not be tested using "instanceof" in catch blocks.
squid:S1118 - Utility classes should not have public constructors.
squid:S2326 - Unused type parameters should be removed.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2864
https://dev.eclipse.org/sonar/rules/show/squid:S1193
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S2326
Please let me know if you have any questions.
George Kankava