### PR TITLE
multiple code improvements: squid:S00105, squid:S2325

### DIFF
--- a/src/main/java/io/katharsis/rs/KatharsisFeature.java
+++ b/src/main/java/io/katharsis/rs/KatharsisFeature.java
@@ -93,7 +93,7 @@ public class KatharsisFeature implements Feature {
 
         KatharsisFilter katharsisFilter;
         try {
-        	ExceptionMapperLookup exceptionMapperLookup = createExceptionMapperLookup(context);
+            ExceptionMapperLookup exceptionMapperLookup = createExceptionMapperLookup(context);
             ExceptionMapperRegistry exceptionMapperRegistry = buildExceptionMapperRegistry(exceptionMapperLookup);
             RequestContextParameterProviderLookup containerRequestContextProviderLookup = createRequestContextProviderLookup(context);
             RequestContextParameterProviderRegistry parameterProviderRegistry = buildParameterProviderRegistry(containerRequestContextProviderLookup);
@@ -111,11 +111,11 @@ public class KatharsisFeature implements Feature {
         return builder.build(containerRequestContextProviderLookup);
     }
 
-    private String buildServiceUrl(String resourceDefaultDomain, String webPathPrefix) {
+    private static String buildServiceUrl(String resourceDefaultDomain, String webPathPrefix) {
         return resourceDefaultDomain + (webPathPrefix != null ? webPathPrefix : "");
     }
 
-    private ExceptionMapperRegistry buildExceptionMapperRegistry(ExceptionMapperLookup exceptionMapperLookup) throws Exception {
+    private static ExceptionMapperRegistry buildExceptionMapperRegistry(ExceptionMapperLookup exceptionMapperLookup) throws Exception {
         ExceptionMapperRegistryBuilder mapperRegistryBuilder = new ExceptionMapperRegistryBuilder();
         return mapperRegistryBuilder.build(exceptionMapperLookup);
     }

--- a/src/main/java/io/katharsis/rs/KatharsisFilter.java
+++ b/src/main/java/io/katharsis/rs/KatharsisFilter.java
@@ -69,7 +69,7 @@ public class KatharsisFilter implements ContainerRequestFilter {
         this.webPathPrefix = parsePrefix(webPathPrefix);
     }
 
-    private String parsePrefix(String webPathPrefix) {
+    private static String parsePrefix(String webPathPrefix) {
         if (webPathPrefix != null && webPathPrefix.startsWith(PathBuilder.SEPARATOR)) {
             return webPathPrefix.substring(1);
         } else {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S00105 Tabulation characters should not be used.
squid:S2325 "private" methods that don't access instance data should be "static".
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS00105
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2325
Please let me know if you have any questions.
George Kankava